### PR TITLE
Remove unnecessary version constraints for json and bundler

### DIFF
--- a/omniauth-oauth2-line.gemspec
+++ b/omniauth-oauth2-line.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'json', '~> 1.3'
+  s.add_dependency 'json'
   s.add_dependency 'omniauth-oauth2', '~>1.6'
-  s.add_development_dependency 'bundler', '~> 1.0'
+  s.add_development_dependency 'bundler'
 
 end


### PR DESCRIPTION
This allows use with the latest json gem and bundler, to eliminate warnings and dependency problems with Ruby >=2.7.